### PR TITLE
Changes in OSX installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,21 @@ Installation on OSX
 The installation on OSX is quite similar to Linux. According to the
 reports for issue #28 you will have to do the following:
 
-1. Download the ```get-pip.py``` script from here:
-   https://raw.github.com/pypa/pip/master/contrib/get-pip.py
-
 1. Open Terminal by typing ```Terminal``` in Spotlight. A command line
    interface should open.
+1. Install pip. To do that, type
+   sudo easy_install pip
+   Note: for this to work you need to have XCode (the Mac developer
+   tools) installed, you will also need the Xcode command line tools,
+   but XCode will prompt you to install them if you don't.
+   Then follow step 
+
+1. Alternatively, if you don't have and don't want to install XCode
+   you can also download the ```get-pip.py``` script from here:
+   https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+   But please be aware that you are doing this at your own risk. You
+   are installing a binary through a script downloaded from the internet
+   without any verification...
 
 1. Change to the ```Downloads``` directory
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ reports for issue #28 you will have to do the following:
    Note: for this to work you need to have XCode (the Mac developer
    tools) installed, you will also need the Xcode command line tools,
    but XCode will prompt you to install them if you don't.
-   Then follow step 
+   Then go to step 5 below. 
 
 1. Alternatively, if you don't have and don't want to install XCode
    you can also download the ```get-pip.py``` script from here:


### PR DESCRIPTION
This is a change to the OSX installation instructions to avoid having to use get-pip.py to install pip. The way get-pip.py installs git is highly obscure and insecure, it should not be suggested by default, no matter how much you may trust it's source.